### PR TITLE
typo: Change 'scripts' to 'tasks' in deno.json

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,5 +1,5 @@
 {
-  "scripts": {
+  "tasks": {
     "dev": "deno run -A index.ts localhost"
   },
   "imports": {


### PR DESCRIPTION
## YO! CHECK THIS OUT! 🎭
- BRUH, we caught this deno.json using `scripts` like it's 1999! 
- Had to drag it into 2024 with `tasks` because that's how we roll now! 🦖

## WHY THO?? 
- Using `scripts` in 2024? That's like using a flip phone at an iPhone party! 💀
- Deno be like "TASKS OR GET REKT FAM!" and we ain't arguing with that
- README was sitting there crying because `deno task dev` was broken AF

## TESTING VIBES
- `deno task dev` is now working like it just hit the gym! 💪
- Deno's not mad anymore (we hope lol)

## PS. DON'T BE MAD BRO
Yo sorry for going full meme mode here! 🙈
But for real tho, this `tasks` thing ain't a joke - it's legit needed!
Peace out! ✌️